### PR TITLE
Fix bin/setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -18,7 +18,7 @@ FileUtils.chdir APP_ROOT do
   system('bundle check') || system!('bundle install')
 
   # Install JavaScript dependencies
-  # system('bin/yarn')
+  system('bin/yarn')
 
   # puts "\n== Copying sample files =="
   # unless File.exist?('config/database.yml')


### PR DESCRIPTION
Yarnのインストールを行うようにする。
Yarnの依存関係がインストールされていない状況で`bin/setup`を実行すると、`db:prepare`のタイミングで落ちていたため。