### PR TITLE
Ruby 2.7.2 から非推奨な警告がデフォルトで出なくなるので明示的に表示するようにする

### DIFF
--- a/bin/rails
+++ b/bin/rails
@@ -1,4 +1,7 @@
 #!/usr/bin/env ruby
+# NOTE: 非推奨な警告を明示的に表示させる
+Warning[:deprecated] = true
+
 begin
   load File.expand_path('../spring', __FILE__)
 rescue LoadError => e


### PR DESCRIPTION
Ruby 2.7.2 から非推奨な警告がデフォルトでは出なくなるので明示的に警告が出るようにしてみる
see: https://www.ruby-lang.org/ja/news/2020/10/02/ruby-2-7-2-released/

### :memo:
* 完全に動作未確認なので https://github.com/mitakarb/beerkeeper/pull/46 がマージされたら動作確認するぞい
* bin/rails だと rspec 実行時に引っかからない気がするのでそのあたりも考慮する必要がありそう（sidekiq みたいなミドルウェア使ってる場合とかも