### PR TITLE
イベント主催者をcurrent_userに限定する

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -22,6 +22,7 @@ class EventsController < ApplicationController
   # POST /events
   def create
     @event = Event.new(event_params)
+    @event.organizer_id = current_user.id
 
     if @event.save
       redirect_to @event, notice: 'Event was successfully created.'
@@ -53,6 +54,6 @@ class EventsController < ApplicationController
 
     # Only allow a trusted parameter "white list" through.
     def event_params
-      params.fetch(:event, {}).permit(:start_at, :end_at, :location, :name, :organizer_id, :max_size, :budget, :description)
+      params.fetch(:event, {}).permit(:start_at, :end_at, :location, :name, :max_size, :budget, :description)
     end
 end

--- a/app/views/events/_form.himl
+++ b/app/views/events/_form.himl
@@ -13,9 +13,6 @@
     <%= form.label :name %>
     <%= form.text_field :name, class: "form-control" %>
   <div class="field form-group">
-    <%= form.label :organizer_id %>
-    <%= form.text_field :organizer_id, class: "form-control" %>
-  <div class="field form-group">
     <%= form.label :max_size %>
     <%= form.number_field :max_size, class: "form-control" %>
   <div class="field form-group">


### PR DESCRIPTION
- 自分以外の他人が主催者になることはない
- formの項目を減らすため