### PR TITLE
Bundle webdrivers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ end
 group :test do
   gem 'capybara', '>= 2.15'
   gem 'selenium-webdriver'
+  gem 'webdrivers'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -207,6 +207,10 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webdrivers (4.4.1)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (>= 3.0, < 4.0)
     webpacker (4.3.0)
       activesupport (>= 4.2)
       rack-proxy (>= 0.6.1)
@@ -240,6 +244,7 @@ DEPENDENCIES
   turbolinks (~> 5)
   tzinfo-data
   web-console (>= 3.3.0)
+  webdrivers
   webpacker (~> 4.0)
 
 RUBY VERSION


### PR DESCRIPTION
`webdrivers` gemをインストールすることで、各自の環境に`chromedriver`などをインストールしなくてもよくなります。