### PR TITLE
Dockerfileで`yarn install`をCOPYの後に行う

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,11 +20,9 @@ COPY Gemfile.lock /myapp/Gemfile.lock
 RUN gem install bundler
 RUN bundle install
 
-COPY package.json /myapp/package.json
-COPY yarn.lock /myapp/yarn.lock
-RUN yarn install
-
 COPY . /myapp
+
+RUN yarn install
 
 # Add a script to be executed every time the container starts.
 COPY entrypoint.sh /usr/bin/


### PR DESCRIPTION
従来のやり方だと、COPYコマンドで直前にインストールした
`node_modules`ディレクトリを上書きしていたっぽい。