### PR TITLE
Bundlerのバージョンを2.2.5に固定

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ WORKDIR /myapp
 
 COPY Gemfile /myapp/Gemfile
 COPY Gemfile.lock /myapp/Gemfile.lock
-RUN gem install bundler
+RUN gem install bundler -v '2.2.5'
 RUN bundle install
 
 COPY . /myapp

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -253,4 +253,4 @@ RUBY VERSION
    ruby 3.0.1p64
 
 BUNDLED WITH
-   2.2.16
+   2.2.5


### PR DESCRIPTION
2.2.19を利用すると、Docker利用時に

```
web_1  | bundler: failed to load command: rails (/usr/local/bundle/bin/rails)
web_1  | /usr/local/bundle/gems/bundler-2.2.19/lib/bundler/spec_set.rb:95:in `block in materialize': Could not find msgpack-1.4.2 in any of the sources (Bundler::GemNotFound)
```

のようなエラーが出る。
2.2.5は以前使っていたバージョンで、こちらでは正常に動くことを確認できた。
しばらくしたら最新版を試すとして、今は2.2.5で動かしたい。
Ref: #74 