### PR TITLE
Dependabotの設定ファイルを追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+- package-ecosystem: bundler
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "21:00"
+  open-pull-requests-limit: 10


### PR DESCRIPTION
Dependabotは設定ファイルがないと動かなくなっているのでは、という懸念があるため（`webpacker`とか古いままになっている）。