### PR TITLE
Bootstrapの適用

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,14 +6,14 @@ WORKDIR /app
 RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash -
 
 # Add packages
-RUN apt update && apt install -y \
+RUN apt-get update && apt-get install -y \
     git \
     nodejs \
     vim
 
 # Add Chrome
 RUN curl -sO https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \
-    && apt install -y ./google-chrome-stable_current_amd64.deb \
+    && apt-get install -y ./google-chrome-stable_current_amd64.deb \
     && rm google-chrome-stable_current_amd64.deb
 
 # Add chromedriver

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,17 +2,14 @@ FROM ruby:3.2.0
 
 WORKDIR /app
 
-# Using Node.js v14.x(LTS)
-RUN curl -fsSL https://deb.nodesource.com/setup_14.x | bash -
+# Using Node.js v18.x(LTS)
+RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash -
 
 # Add packages
-RUN apt-get update && apt-get install -y \
+RUN apt update && apt install -y \
     git \
     nodejs \
     vim
-
-# Add yarnpkg for assets:precompile
-RUN npm install -g yarn
 
 # Add Chrome
 RUN curl -sO https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \

--- a/Gemfile
+++ b/Gemfile
@@ -14,8 +14,10 @@ gem "puma", "~> 6.0"
 
 # Use JavaScript with ESM import maps [https://github.com/rails/importmap-rails]
 gem "importmap-rails"
-gem "cssbundling-rails"
 gem "propshaft"
+
+# Bootstrap
+gem "bootstrap"
 
 # Hotwire's SPA-like page accelerator [https://turbo.hotwired.dev]
 gem "turbo-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,10 +96,16 @@ GEM
   specs:
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
+    autoprefixer-rails (10.4.7.0)
+      execjs (~> 2)
     bcrypt (3.1.18)
     bindex (0.8.1)
     bootsnap (1.16.0)
       msgpack (~> 1.2)
+    bootstrap (5.2.3)
+      autoprefixer-rails (>= 9.1.0)
+      popper_js (>= 2.11.6, < 3)
+      sassc-rails (>= 2.0.0)
     builder (3.2.4)
     capybara (3.38.0)
       addressable
@@ -113,8 +119,6 @@ GEM
     concurrent-ruby (1.2.0)
     connection_pool (2.3.0)
     crass (1.0.6)
-    cssbundling-rails (1.1.2)
-      railties (>= 6.0.0)
     dartsass-rails (0.4.1)
       railties (>= 6.0.0)
     date (3.3.3)
@@ -123,11 +127,13 @@ GEM
       reline (>= 0.3.1)
     diff-lcs (1.5.0)
     erubi (1.12.0)
+    execjs (2.8.1)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
+    ffi (1.15.5)
     globalid (1.1.0)
       activesupport (>= 5.0)
     i18n (1.12.0)
@@ -169,6 +175,7 @@ GEM
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     pg (1.4.5)
+    popper_js (2.11.6)
     propshaft (0.6.4)
       actionpack (>= 7.0.0)
       activesupport (>= 7.0.0)
@@ -216,13 +223,29 @@ GEM
       rspec-support (~> 3.11)
     rspec-support (3.12.0)
     rubyzip (2.3.2)
+    sassc (2.4.0)
+      ffi (~> 1.9)
+    sassc-rails (2.1.2)
+      railties (>= 4.0.0)
+      sassc (>= 2.0)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     selenium-webdriver (4.8.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    sprockets (4.2.0)
+      concurrent-ruby (~> 1.0)
+      rack (>= 2.2.4, < 4)
+    sprockets-rails (3.4.2)
+      actionpack (>= 5.2)
+      activesupport (>= 5.2)
+      sprockets (>= 3.0.0)
     stimulus-rails (1.2.1)
       railties (>= 6.0.0)
     thor (1.2.1)
+    tilt (2.1.0)
     timeout (0.3.1)
     turbo-rails (1.3.3)
       actionpack (>= 6.0.0)
@@ -253,8 +276,8 @@ PLATFORMS
 DEPENDENCIES
   bcrypt (~> 3.1.18)
   bootsnap
+  bootstrap
   capybara
-  cssbundling-rails
   dartsass-rails (~> 0.4.1)
   debug
   factory_bot_rails

--- a/README.md
+++ b/README.md
@@ -14,21 +14,21 @@ mitaka.rb で作っているイベント管理アプリです :beers:
 
 ```shell
 # beerkeeperのDocker環境を過去に作ったことがあり、まっさらにしたい時
-$ docker-compose down --volumes
+$ docker compose down --volumes
 
 # まっさらな状態からやるとき
 $ git clone https://github.com/mitakarb/beerkeeper.git
 $ cd beerkeeper
-$ docker-compose build
-$ docker-compose run --rm web bin/setup
-$ docker-compose up
+$ docker compose build
+$ docker compose run --rm web bin/setup
+$ docker compose up
 # http://localhost:3000/ を確認
 
 # test
 ## 初回のみ
-$ docker-compose run --rm -e RAILS_ENV=test web bin/rails db:test:prepare
+$ docker compose run --rm -e RAILS_ENV=test web bin/rails db:test:prepare
 ## spec実行
-$ docker-compose run --rm -e RAILS_ENV=test web bundle exec rspec
+$ docker compose run --rm -e RAILS_ENV=test web bundle exec rspec
 ```
 
 ## local
@@ -42,4 +42,5 @@ $ bin/dev
 ```
 
 ## 動作確認
-- http://localhost:3000/ を開いてイベント一覧が表示されたらOKです:)
+
+http://localhost:3000/ を開いてイベント一覧が表示されたらOKです:)

--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -1,2 +1,3 @@
-@import 'bootstrap/scss/bootstrap';
-@import 'bootstrap-icons/font/bootstrap-icons';
+// @import url("https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css");
+
+@import "bootstrap";

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,1 +1,3 @@
 // Entry point for your Sass build
+
+@import "./application.bootstrap.scss"

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,4 +1,4 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
-import * as Popper from "@popperjs/core"
-import * as Bootstrap from "bootstrap"
-import "@hotwired/turbo-rails"
+import * as Popper from "@popperjs/core";
+import * as Bootstrap from "bootstrap";
+import "@hotwired/turbo-rails";

--- a/app/javascript/src/application.scss
+++ b/app/javascript/src/application.scss
@@ -1,1 +1,1 @@
-@import 'bootstrap/scss/bootstrap';
+// @import 'bootstrap/scss/bootstrap';

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -1,8 +1,8 @@
 # Pin npm packages by running ./bin/importmap
 
 pin "application", preload: true
-pin "bootstrap", to: "https://ga.jspm.io/npm:bootstrap@5.1.3/dist/js/bootstrap.esm.js"
-pin "@popperjs/core", to: "https://ga.jspm.io/npm:@popperjs/core@2.11.5/lib/index.js"
+pin "bootstrap", to: "https://ga.jspm.io/npm:bootstrap@5.2.3/dist/js/bootstrap.esm.js"
+pin "@popperjs/core", to: "https://ga.jspm.io/npm:@popperjs/core@2.11.6/lib/index.js"
 pin "@hotwired/turbo-rails", to: "turbo.min.js", preload: true
 pin "@hotwired/stimulus", to: "stimulus.min.js", preload: true
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js", preload: true


### PR DESCRIPTION
## 実装内容

### `gem "bootstrap"` を追加しました。

適用させるために assets配下の `scss`ファイルに `@import "bootstrap"` を記述し適用させています。
gemなしでやる場合、 css-bundlingをいれて `package.json` `yarn` でBootstrapをいれなければいけないようです。
nodejsを完全に剥がせると思ったのですが、依存gemの`execjs`がnodeを要求しているため剥がせず。。（tailwindなら剥がせるかもしれません（未検証））

![image](https://user-images.githubusercontent.com/12590762/221397623-8d089066-2fcb-4622-9541-9de5cfc6d0e3.png)

