### PR TITLE
docker-compose.yml tmpfsのpidsディレクトリのパスを修正

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - bundle:/app/vendor/bundle
       - rails_cache:/app/tmp/cache
     tmpfs:
-      - /app/beerkeeper/tmp/pids
+      - /app/tmp/pids
       - /tmp
     environment:
       BUNDLE_PATH: "/app/vendor/bundle"


### PR DESCRIPTION
## 内容

Dockerで環境構築をした場合、beerkeeperディレクトリ配下に`beerkeeper/tmp/pids`が作成されていた。
docker-compose.ymlのtmpfsの指定を、beerkeeperディレクトリ配下の`tmp/pids`にするように修正。


### Dockerコンテナ内パス

Dockerコンテナ内は`/app`がbeerkeeperのRAILS_ROOTになるため、beerkeeperディレクトリは不要

- 変更前
  - `/app/beerkeeper/tmp/pids`
- 変更後
  - `/app/tmp/pids`
