### PR TITLE
Docker Composeでweb-consoleを使うためのの設定を追記

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -67,4 +67,6 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
+
+  config.web_console.allowed_ips = %w[0.0.0.0/0]
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,7 @@ services:
       EDITOR: "vi"
       DATABASE_URL: "postgres://postgres:postgres@db:5432"
       REDIS_URL: "redis://redis:6379/"
+      BINDING: "0.0.0.0"
       RAILS_MASTER_KEY:
     depends_on:
       - db


### PR DESCRIPTION
Docker ComposeでもWeb-Consoleを使うための設定を追記しました。

![image](https://github.com/mitakarb/beerkeeper/assets/12590762/2cfc114b-a443-4aaf-8b08-4fe79fbce2d6)

https://techracho.bpsinc.jp/hachi8833/2022_01_19/114936
https://zenn.dev/junki555/articles/571d76310a9c9c
https://techracho.bpsinc.jp/hachi8833/2021_03_25/83450
