### PR TITLE
Dockerfile のM1 Mac対応

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,18 +6,8 @@ WORKDIR /app
 RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash -
 
 # Add packages
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y \
     git \
     nodejs \
-    vim
-
-# Add Chrome
-RUN curl -sO https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \
-    && apt-get install -y ./google-chrome-stable_current_amd64.deb \
-    && rm google-chrome-stable_current_amd64.deb
-
-# Add chromedriver
-RUN CHROME_DRIVER_VERSION=`curl -sS chromedriver.storage.googleapis.com/LATEST_RELEASE` \
-    && curl -sO https://chromedriver.storage.googleapis.com/$CHROME_DRIVER_VERSION/chromedriver_linux64.zip \
-    && unzip chromedriver_linux64.zip \
-    && mv chromedriver /usr/bin/chromedriver
+    vim \
+    chromium

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,5 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y \
     git \
     nodejs \
     vim \
-    chromium
+    chromium \
+    chromium-driver

--- a/Gemfile
+++ b/Gemfile
@@ -71,7 +71,6 @@ group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"
   gem "selenium-webdriver"
-  gem "webdrivers"
   gem "rspec-rails"
   gem "factory_bot_rails"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -295,10 +295,6 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (5.2.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0)
     webrick (1.8.1)
     websocket (1.2.9)
     websocket-driver (0.7.6)
@@ -334,7 +330,6 @@ DEPENDENCIES
   tzinfo-data
   view_component (~> 3.6)
   web-console
-  webdrivers
 
 RUBY VERSION
    ruby 3.2.2p53

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
 
   web: &web
     build: .
-    image: app:1.0.0
+    image: app:1.1.0
     stdin_open: true
     tty: true
     volumes:

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,0 +1,19 @@
+Capybara.register_driver :selenium_chrome_headless do |app|
+  options = ::Selenium::WebDriver::Chrome::Options.new
+  options.add_argument('--headless')
+  options.add_argument('--no-sandbox')
+  options.add_argument('--disable-gpu')
+  options.add_argument('--disable-dev-shm-usage')
+  options.add_argument('--window-size=1400,1400')
+  driver = Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
+end
+
+RSpec.configure do |config|
+  config.before(:each, type: :system) do
+    driven_by :rack_test
+  end
+
+  config.before(:each, type: :system, js: true) do
+    driven_by(:selenium_chrome_headless)
+  end
+end

--- a/spec/system/events_spec.rb
+++ b/spec/system/events_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "events", type: :system do
+RSpec.describe "events", type: :system, js: true do
   it "enables me to create widgets" do
     visit "/events" # /booksへHTTPメソッドGETでアクセス
     expect(page).to have_text("イベント一覧") # 表示されたページに Books という文字があることを確認

--- a/spec/system/participations_spec.rb
+++ b/spec/system/participations_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Participations', type: :system do
+RSpec.describe 'Participations', type: :system, js: true do
   let(:user) { create(:user) }
   let(:organizer) { create(:user) }
   let(:event) { create(:event, organizer: organizer) }

--- a/spec/system/registrations_spec.rb
+++ b/spec/system/registrations_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "registrations", type: :system do
+RSpec.describe "registrations", type: :system, js: true do
   describe "Signup" do
     before do
       visit signup_path

--- a/spec/system/sessions_spec.rb
+++ b/spec/system/sessions_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "sessions", type: :system do
+RSpec.describe "sessions", type: :system, js: true do
   describe "Login" do
     let(:user) { FactoryBot.create(:user) }
 


### PR DESCRIPTION
chromiumに変更。M1 Macでは動いたので、AMD64なWin機などで動作確認した後にWIP外しますー

```
docker compose run --rm -e RAILS_ENV=test web bundle exec rspec
[+] Creating 2/0
 ✔ Container beerkeeper-redis-1  Running                                                                              0.0s 
 ✔ Container beerkeeper-db-1     Running                                                                              0.0s 
*..........I, [2023-09-14T11:52:12.452155 #49]  INFO -- : Removed /app/public/assets


Pending: (Failures listed here are expected and do not affect your suite's status)

  1) Event add some examples to (or delete) /app/spec/models/event_spec.rb
     # Not yet implemented
     # ./spec/models/event_spec.rb:4


Finished in 3.42 seconds (files took 1.2 seconds to load)
11 examples, 0 failures, 1 pending
```

## メモ
以前、M1 Macで`docker compose up`したらこうなってた

```
$ docker compose up
# 省略
 => ERROR [web 5/6] RUN curl -sO https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb     && apt-get install -y ./  124.8s
------
 > [web 5/6] RUN curl -sO https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb     && apt-get install -y ./google-chrome-stable_current_amd64.deb     && rm google-chrome-stable_current_amd64.deb:
124.2 Reading package lists...
124.6 Building dependency tree...
124.7 Reading state information...
124.7 Some packages could not be installed. This may mean that you have
124.7 requested an impossible situation or if you are using the unstable
124.7 distribution that some required packages have not yet been created
124.7 or been moved out of Incoming.
124.7 The following information may help to resolve the situation:
124.7 
124.7 The following packages have unmet dependencies:
124.7  google-chrome-stable:amd64 : Depends: libasound2:amd64 (>= 1.0.17) but it is not installable
124.7                               Depends: libatk-bridge2.0-0:amd64 (>= 2.5.3) but it is not installable
124.7                               Depends: libatk1.0-0:amd64 (>= 2.2.0) but it is not installable
124.7                               Depends: libatspi2.0-0:amd64 (>= 2.9.90) but it is not installable
124.7                               Depends: libc6:amd64 (>= 2.17) but it is not installable
124.7                               Depends: libcairo2:amd64 (>= 1.6.0) but it is not installable
124.7                               Depends: libcups2:amd64 (>= 1.6.0) but it is not installable
124.7                               Depends: libcurl3-gnutls:amd64 but it is not installable or
124.7                                        libcurl3-nss:amd64 but it is not installable or
124.7                                        libcurl4:amd64 but it is not installable or
124.7                                        libcurl3:amd64 but it is not installable
124.7                               Depends: libdbus-1-3:amd64 (>= 1.9.14) but it is not installable
124.7                               Depends: libdrm2:amd64 (>= 2.4.75) but it is not installable
124.7                               Depends: libexpat1:amd64 (>= 2.1~beta3) but it is not installable
124.7                               Depends: libgbm1:amd64 (>= 17.1.0~rc2) but it is not installable
124.7                               Depends: libglib2.0-0:amd64 (>= 2.39.4) but it is not installable
124.7                               Depends: libgtk-3-0:amd64 (>= 3.9.10) but it is not installable or
124.7                                        libgtk-4-1:amd64 but it is not installable
124.7                               Depends: libnspr4:amd64 (>= 2:4.9-2~) but it is not installable
124.7                               Depends: libnss3:amd64 (>= 2:3.35) but it is not installable
124.7                               Depends: libpango-1.0-0:amd64 (>= 1.14.0) but it is not installable
124.7                               Depends: libvulkan1:amd64 but it is not installable
124.7                               Depends: libx11-6:amd64 (>= 2:1.4.99.1) but it is not installable
124.7                               Depends: libxcb1:amd64 (>= 1.9.2) but it is not installable
124.7                               Depends: libxcomposite1:amd64 (>= 1:0.4.4-1) but it is not installable
124.7                               Depends: libxdamage1:amd64 (>= 1:1.1) but it is not installable
124.7                               Depends: libxext6:amd64 but it is not installable
124.7                               Depends: libxfixes3:amd64 but it is not installable
124.7                               Depends: libxkbcommon0:amd64 (>= 0.5.0) but it is not installable
124.7                               Depends: libxrandr2:amd64 but it is not installable
124.7 E: Unable to correct problems, you have held broken packages.
------
failed to solve: process "/bin/sh -c curl -sO https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb     && apt-get install -y ./google-chrome-stable_current_amd64.deb     && rm google-chrome-stable_current_amd64.deb" did not complete successfully: exit code: 100
```