### PR TITLE
emailにユニークを確認するバリデーションを追加

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,7 @@ class User < ApplicationRecord
   has_many :participations, dependent: :nullify
 
   validates :name, presence: true
-  validates :email, presence: true, format: { with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i }
+  validates :email, presence: true, format: { with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i }, uniqueness: { case_sensitive: false }
 
   def participatable?(event)
     !participations.find_by(event_id: event.id)


### PR DESCRIPTION
同じemailで登録しようとするとDB側のユニーク制約に引っかかりエラーが発生するので、rails側で定義しているemailのvalidationにもユニーク制約を追加した。（メールアドレスの大文字・小文字の区別までは見ないようにしています）