### PR TITLE
WIP: VSCode向けにDev Containers, Task, Debug(launch)の設定を追加

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+{
+  "name": "Dev Container",
+  "dockerComposeFile": [
+    "../docker-compose.yml",
+    "docker-compose.yml"
+  ],
+  "service": "web",
+  "runServices": [
+    "web",
+    "db",
+    "redis"
+  ],
+  "workspaceFolder": "/app",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "rebornix.ruby",
+        "KoichiSasada.vscode-rdbg"
+      ],
+      "settings": {
+        "ruby.useLanguageServer": true
+      }
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,8 +14,8 @@
   "customizations": {
     "vscode": {
       "extensions": [
-        "rebornix.ruby",
-        "KoichiSasada.vscode-rdbg"
+        "KoichiSasada.vscode-rdbg",
+        "Shopify.ruby-lsp"
       ],
       "settings": {
         "ruby.useLanguageServer": true

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3'
+
+services:
+  web:
+    command: sleep infinity
+    volumes:
+      - vscode_server:/root/.vscode-server
+
+volumes:
+  vscode_server:
+

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -5,6 +5,10 @@ services:
     command: sleep infinity
     volumes:
       - vscode_server:/root/.vscode-server
+      - bundle:/usr/local/bundle
+    environment:
+      BUNDLE_PATH: # ruby-lsp拡張が動作しないため、空で上書き
+      BOOTSNAP_CACHE_DIR: # ruby-lsp拡張が動作しないため、空で上書き
 
 volumes:
   vscode_server:

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@
 
 /app/assets/builds/*
 !/app/assets/builds/.keep
+
+/vendor/bundle

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+    // IntelliSense を使用して利用可能な属性を学べます。
+    // 既存の属性の説明をホバーして表示します。
+    // 詳細情報は次を確認してください: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug Rails server",
+            "type": "rdbg",
+            "request": "launch",
+            "rdbgPath": "bundle exec rdbg",
+            "cwd": "${workspaceRoot}",
+            "command": "bin/rails",
+            "script": "s",
+            "env": {
+                "WEB_CONCURRENCY": 0,
+            },
+            "useBundler": true,
+        },
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,22 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Run rails server",
+            "type": "shell",
+            "command": "bin/rails server",
+        },
+        {
+            "label": "Run rails dartsass:watch",
+            "type": "shell",
+            "command": "bin/rails dartsass:watch",
+        },
+        {
+            "label": "Run rspec",
+            "type": "shell",
+            "command": "bundle exec rspec"
+        },
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,14 +4,14 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "label": "Run rails server",
+            "label": "Run dev",
             "type": "shell",
-            "command": "bin/rails server",
+            "command": "bin/dev"
         },
         {
-            "label": "Run rails dartsass:watch",
+            "label": "Run dev without web",
             "type": "shell",
-            "command": "bin/rails dartsass:watch",
+            "command": "bin/dev -m all=1,web=0"
         },
         {
             "label": "Run rspec",

--- a/bin/dev
+++ b/bin/dev
@@ -6,4 +6,4 @@ then
   gem install foreman
 fi
 
-foreman start -f Procfile.dev
+foreman start -f Procfile.dev "$@"


### PR DESCRIPTION
## 内容

[esa](https://mitakarb.esa.io/posts/58) にdevcontainerの記載があったので、VSCode向けにDev Containers, Task, Debug(launch)の設定を追加してみました。
既存の`docker-compose.yml`は変更していないので、READMEのUse Dockerの手順はそのまま使用できます。


### Dev Containers について

https://code.visualstudio.com/docs/devcontainers/containers

VSCodeで使用するには、[拡張機能 Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)のインストールが必要です。
VSCodeでのDev Containersの使用方法は、[拡張機能 Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)を参照ください。

### Task について

https://code.visualstudio.com/docs/editor/tasks

`bin/rails server`などをVSCodeのコマンドパレットから簡単に実行できるように、`tasks.json`を追加しています。

### Debug(launch) について

https://code.visualstudio.com/docs/editor/debugging

`bin/rails server`をvscode-rdbg(debug.gem)経由で実行・デバックできるように、`launch.json`を追加しています。

