### PR TITLE
Add devcongainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,15 @@
+{
+  "name": "Rails Dev Container",
+  "dockerComposeFile": [
+    "../docker-compose.yml"
+  ],
+  "service": "web",
+  "workspaceFolder": "/app",
+  "customizations": {
+  "vscode": {
+    "extensions": [
+        "Shopify.ruby-extensions-pack"
+      ]
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@
 
 /app/assets/builds/*
 !/app/assets/builds/.keep
+
+/vendor/bundle

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "ms-vscode-remote.vscode-remote-extensionpack",
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "[ruby]": {
+    "editor.tabSize": 2
+  }
+}


### PR DESCRIPTION
vs codeでdevcontainerを使えるようにする

docker起動＋↓の拡張機能を入れて

https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack

左下の青ポチをクリックしてコンテナで開く

![スクリーンショット 2024-04-11 21 05 07](https://github.com/mitakarb/beerkeeper/assets/756736/8c44e570-62ba-421c-b1dd-874b9d99aba2)

抜ける場合は同じところをクリックしてclose remote connection

![スクリーンショット 2024-04-11 21 06 02](https://github.com/mitakarb/beerkeeper/assets/756736/af536a46-487e-4d3c-9179-d169d6a15e0d)

 ターミナルはコンテナ内で叩くことになるので、`docker compose --rm web` 的なのは不要

![スクリーンショット 2024-04-11 21 07 31](https://github.com/mitakarb/beerkeeper/assets/756736/efafd26c-bc4a-42bb-be8d-a20ae2030bd5)
