### PR TITLE
タイムゾーンをTokyoに設定し、イベント日時をフォーマット表示・開始日時・終了日時の必須バリデーションを追加

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,6 +1,8 @@
 class Event < ApplicationRecord
   belongs_to :organizer, class_name: 'User'
 
+  validates :start_at, presence: true
+  validates :end_at, presence: true
   validates :name, presence: true
 
   def organizer?(user)

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -2,10 +2,10 @@
 
 <ul class="list-group">
   <li class="list-group-item">
-    開始日時: <%= @event.start_at %>
+    開始日時: <%= l(@event.start_at, format: :long) %>
   </li>
   <li class="list-group-item">
-    終了日時: <%= @event.end_at %>
+    終了日時: <%= l(@event.end_at, format: :long) %>
   </li>
   <li class="list-group-item">
     開催場所: <%= @event.location %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -2,10 +2,10 @@
 
 <ul class="list-group">
   <li class="list-group-item">
-    開始日時: <%= l(@event.start_at, format: :long) %>
+    開始日時: <%= l(@event.start_at) %>
   </li>
   <li class="list-group-item">
-    終了日時: <%= l(@event.end_at, format: :long) %>
+    終了日時: <%= l(@event.end_at) %>
   </li>
   <li class="list-group-item">
     開催場所: <%= @event.location %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,6 +20,7 @@ module Beerkeeper
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
     config.i18n.default_locale = :ja
+    config.time_zone = 'Tokyo'
     config.view_component.preview_paths << "#{Rails.root}/spec/components/previews"
   end
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -3,3 +3,7 @@ ja:
     format: "%{attribute} %{message}"
     messages:
       invalid: の形式が不正です
+
+  time:
+    formats:
+      default: "%Y年%m月%d日(%a) %H時%M分"

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -1,6 +1,8 @@
 FactoryBot.define do
   factory :event do
     organizer factory: :user
+    start_at { Time.current + 1.day }
+    end_at { Time.current + 1.day + 1.hour }
     name { 'The event' }
   end
 end


### PR DESCRIPTION
fix #735