### PR TITLE
未ログイン状態でイベント詳細を表示するとエラーの修正

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -6,6 +6,6 @@ class Event < ApplicationRecord
   validates :name, presence: true
 
   def organizer?(user)
-    organizer_id == user.id
+    organizer_id == user&.id
   end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -18,4 +18,22 @@ RSpec.describe Event, type: :model do
       end
     end
   end
+
+  describe '#organizer?' do
+    let!(:event) { FactoryBot.create(:event) }
+
+    context '引数がnilの場合' do
+      it { expect(event.organizer?(nil)).to be_falsey }
+    end
+
+    context '引数がオーガナイザーの場合' do
+      it { expect(event.organizer?(event.organizer)).to be_truthy }
+    end
+
+    context '引数がオーガナイザーでない場合' do
+      let!(:user) { FactoryBot.create(:user) }
+
+      it { expect(event.organizer?(user)).to be_falsey }
+    end
+  end
 end


### PR DESCRIPTION
- 🎫: fix #797 
- Why?
    - userがnilの時がある
- What?
    - nilのときはnil返す
