### PR TITLE
:arrow_up: bootstrap gemのバージョンを最新の固定バージョンにする

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem "rails", "~> 8.0.0"
 
 gem "bcrypt", "~> 3.1.20"
 gem "bootsnap", require: false
-gem "bootstrap", github: 'twbs/bootstrap-rubygem' # v 5.3.3 should fix the problem, but not released yet
+gem "bootstrap", "~> 5.3.3"
 gem "dartsass-rails", "~> 0.5.1"
 gem "importmap-rails"
 gem "jbuilder"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,3 @@
-GIT
-  remote: https://github.com/twbs/bootstrap-rubygem.git
-  revision: 1e6b6b24afe23fe93042a413b4e9cf8dbc1f0a3e
-  specs:
-    bootstrap (5.3.3)
-      popper_js (>= 2.11.8, < 3)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -81,6 +74,8 @@ GEM
       uri (>= 0.13.1)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
+    autoprefixer-rails (10.4.19.0)
+      execjs (~> 2)
     base64 (0.2.0)
     bcrypt (3.1.20)
     benchmark (0.4.0)
@@ -88,6 +83,9 @@ GEM
     bindex (0.8.1)
     bootsnap (1.18.4)
       msgpack (~> 1.2)
+    bootstrap (5.3.3)
+      autoprefixer-rails (>= 9.1.0)
+      popper_js (>= 2.11.8, < 3)
     builder (3.3.0)
     capybara (3.40.0)
       addressable
@@ -111,6 +109,7 @@ GEM
     diff-lcs (1.5.1)
     drb (2.2.1)
     erubi (1.13.0)
+    execjs (2.10.0)
     factory_bot (6.5.0)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.4.4)
@@ -302,7 +301,7 @@ PLATFORMS
 DEPENDENCIES
   bcrypt (~> 3.1.20)
   bootsnap
-  bootstrap!
+  bootstrap (~> 5.3.3)
   capybara
   dartsass-rails (~> 0.5.1)
   debug


### PR DESCRIPTION
rspecがうまく動かない問題が解消されたため

- 🎫:
- Why?
- What?
