### PR TITLE
new_framework_defaults_8_0.rb を復活させる

### DIFF
--- a/config/initializers/new_framework_defaults_8_0.rb
+++ b/config/initializers/new_framework_defaults_8_0.rb
@@ -1,0 +1,30 @@
+# Be sure to restart your server when you modify this file.
+#
+# This file eases your Rails 8.0 framework defaults upgrade.
+#
+# Uncomment each configuration one by one to switch to the new default.
+# Once your application is ready to run with all new defaults, you can remove
+# this file and set the `config.load_defaults` to `8.0`.
+#
+# Read the Guide for Upgrading Ruby on Rails for more info on each option.
+# https://guides.rubyonrails.org/upgrading_ruby_on_rails.html
+
+###
+# Specifies whether `to_time` methods preserve the UTC offset of their receivers or preserves the timezone.
+# If set to `:zone`, `to_time` methods will use the timezone of their receivers.
+# If set to `:offset`, `to_time` methods will use the UTC offset.
+# If `false`, `to_time` methods will convert to the local system UTC offset instead.
+#++
+# Rails.application.config.active_support.to_time_preserves_timezone = :zone
+
+###
+# When both `If-Modified-Since` and `If-None-Match` are provided by the client
+# only consider `If-None-Match` as specified by RFC 7232 Section 6.
+# If set to `false` both conditions need to be satisfied.
+#++
+# Rails.application.config.action_dispatch.strict_freshness = true
+
+###
+# Set `Regexp.timeout` to `1`s by default to improve security over Regexp Denial-of-Service attacks.
+#++
+# Regexp.timeout = 1


### PR DESCRIPTION
- Why?
  - refs. [Railsのnew\_framework\_defaultsとの向き合い方 \- Money Forward Developers Blog](https://moneyforward-dev.jp/entry/2022/05/18/new_framework_defaults-for-rails/)
  - new_framework_defaults は load_defaults を該当バージョンに上げるまでは残しておかないとダメでした。
- What?
  - 「要らないんじゃね？」と言って消してしまってすいませんでした 🙏 