### PR TITLE
ruby_head_spec.yml に workflow_dispatch を追加

### DIFF
--- a/.github/workflows/ruby_head_specs.yml
+++ b/.github/workflows/ruby_head_specs.yml
@@ -2,7 +2,8 @@ name: Ruby Head Specs
 
 on:
   schedule:
-    - cron: '0 0 * * 1-5'  # Run at midnight on weekdays
+    - cron: '0 0 * * 1-5'
+  workflow_dispatch:
 
 env:
   RAILS_ENV: test
@@ -10,8 +11,8 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
-    continue-on-error: true  # Allow failures on Ruby head
-    timeout-minutes: 30      # Extended timeout for debug build
+    continue-on-error: true
+    timeout-minutes: 30
     services:
       db:
         image: postgres


### PR DESCRIPTION
- 🎫:
- Why?
ruby_head_spec.yml を手動実行可能にするため
- What?
`workflow_dispatch`を上記ymlに追加
