### PR TITLE
Fix #94 無理やりだけどBootstrapは古いので、いったんこれで

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,7 +16,7 @@
       <%= link_to root_path, class: 'navbar-brand' do %>
         <%= image_tag "logo.svg", width: '180' %>
       <% end %>
-      <div class="collapse navbar-collapse" id="navbarSupportedContent">
+      <div class="navbar-collapse" id="navbarSupportedContent">
         <ul class="navbar-nav mr-auto d-flex flex-row-reverse w-100">
           <li class="nav-item active">
             <% if current_user %>


### PR DESCRIPTION
- 🎫: https://github.com/mitakarb/beerkeeper/issues/94
- Why? 使いにくいため
- What? 幅を狭くしても見えるようにした


memo:
そのうちTailwindにしたい