### PR TITLE
Evevent create error message

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -28,7 +28,7 @@ class EventsController < ApplicationController
     if @event.save
       redirect_to @event, notice: 'Event was successfully created.'
     else
-
+      flash[:alert] = "Event creation failed."
       render :new
     end
   end
@@ -38,7 +38,7 @@ class EventsController < ApplicationController
     if @event.update(event_params)
       redirect_to @event, notice: 'Event was successfully updated.'
     else
-      render :edit, alert: 'Event creation failed.'
+      render :edit
     end
   end
 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -28,6 +28,7 @@ class EventsController < ApplicationController
     if @event.save
       redirect_to @event, notice: 'Event was successfully created.'
     else
+
       render :new
     end
   end
@@ -37,7 +38,7 @@ class EventsController < ApplicationController
     if @event.update(event_params)
       redirect_to @event, notice: 'Event was successfully updated.'
     else
-      render :edit
+      render :edit, alert: 'Event creation failed.'
     end
   end
 


### PR DESCRIPTION
- 🎫: close #739 
- Why? 
   - イベント作成時、名前を入力せず「保存」を押した際に保存は失敗するが、メッセージがなくわかりにくいためメッセージを追加
- What?
  -  `flash[:alert] = "Event creation failed."`の追加
