### PR TITLE
Assign config.view_component.preview_paths because it's nil

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -25,6 +25,6 @@ module Beerkeeper
     # config.eager_load_paths << Rails.root.join("extras")
     config.i18n.default_locale = :ja
     config.time_zone = 'Tokyo'
-    config.view_component.preview_paths << "#{Rails.root}/spec/components/previews"
+    config.view_component.preview_paths = ["#{Rails.root}/spec/components/previews"]
   end
 end


### PR DESCRIPTION
- 🎫:
- Why? `config.view_component.preview_paths` が `nil` で `<<` で値を設定できないため
- What? `<<` ではなく `=` でアサインするようにした
