### PR TITLE
foreman が install されていない時に、install できるように対応

### DIFF
--- a/bin/dev
+++ b/bin/dev
@@ -1,9 +1,16 @@
 #!/usr/bin/env bash
 
-if ! command -v foreman &> /dev/null
-then
+if ! gem list foreman -i --silent; then
   echo "Installing foreman..."
   gem install foreman
 fi
 
-foreman start -f Procfile.dev
+# Default to port 3000 if not specified
+export PORT="${PORT:-3000}"
+
+# Let the debug gem allow remote connections,
+# but avoid loading until `debugger` is called
+export RUBY_DEBUG_OPEN="true"
+export RUBY_DEBUG_LAZY="true"
+
+exec foreman start -f Procfile.dev "$@"


### PR DESCRIPTION
- 🎫: fixes: #1089
- Why?
foreman が install されていない時に、install する処理が走らなかったため
- What?
foreman が install されていない時に、install できるように対応

