### PR TITLE
schema.rb のカラム並びをアルファベット順に修正

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,36 +10,36 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2022_05_12_122510) do
+ActiveRecord::Schema[8.1].define(version: 2022_05_12_122510) do
   create_table "events", force: :cascade do |t|
-    t.datetime "start_at", precision: nil
+    t.string "budget"
+    t.datetime "created_at", null: false
+    t.text "description"
     t.datetime "end_at", precision: nil
     t.string "location"
+    t.integer "max_size"
     t.string "name", null: false
     t.integer "organizer_id", null: false
-    t.integer "max_size"
-    t.string "budget"
-    t.text "description"
-    t.datetime "created_at", null: false
+    t.datetime "start_at", precision: nil
     t.datetime "updated_at", null: false
     t.index ["organizer_id"], name: "index_events_on_organizer_id"
   end
 
   create_table "participations", force: :cascade do |t|
-    t.integer "user_id", null: false
-    t.integer "event_id", null: false
     t.datetime "created_at", null: false
+    t.integer "event_id", null: false
     t.datetime "updated_at", null: false
+    t.integer "user_id", null: false
     t.index ["event_id"], name: "index_participations_on_event_id"
     t.index ["user_id"], name: "index_participations_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
-    t.string "name"
     t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.string "email", null: false
+    t.string "name"
     t.string "password_digest", null: false
+    t.datetime "updated_at", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 


### PR DESCRIPTION
- 🎫:
Rails 8.1 からデフォルトでカラムの並びがアルファベットになったため、schema.rb のカラム並びをアルファベット順に修正しました。
refs: [Sort table columns by name when dumping schema by jduff · Pull Request \#53281 · rails/rails](https://github.com/rails/rails/pull/53281)

- Why?
bin/setup 時に上記差分が出ていたため、修正しています。

- What?
Rails 8.1 からデフォルトでカラムの並びがアルファベットになったため、schema.rb のカラム並びをアルファベット順に修正しました。