### PR TITLE
fix イベント作成失敗時の入力内容を保持する

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -28,7 +28,7 @@ class EventsController < ApplicationController
     if @event.save
       redirect_to @event, notice: 'Event was successfully created.'
     else
-      flash[:alert] = "Event creation failed."
+      flash.now[:alert] = @event.errors.full_messages.join('、')
       render :new, status: :unprocessable_entity
     end
   end
@@ -38,7 +38,7 @@ class EventsController < ApplicationController
     if @event.update(event_params)
       redirect_to @event, notice: 'Event was successfully updated.'
     else
-      flash[:alert] = "Event update failed."
+      flash.now[:alert] = @event.errors.full_messages.join('、')
       render :edit, status: :unprocessable_entity
     end
   end
@@ -85,7 +85,7 @@ class EventsController < ApplicationController
       if permitted[:end_at_date].present? && permitted[:end_at_time].present?
         permitted[:end_at] = parse_datetime(permitted[:end_at_date], permitted[:end_at_time])
       end
-      permitted.except(:start_at_date, :start_at_time, :end_at_date, :end_at_time)
+      permitted
     end
 
     def parse_datetime(date, time)

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,4 +1,6 @@
 class Event < ApplicationRecord
+  attr_accessor :start_at_date, :start_at_time, :end_at_date, :end_at_time
+
   belongs_to :organizer, class_name: 'User'
   has_many :participations, dependent: :restrict_with_error
 

--- a/app/views/events/_form.erb
+++ b/app/views/events/_form.erb
@@ -14,14 +14,14 @@
                   <%= form.date_field :start_at,
                       name: "event[start_at_date]",
                       id: "event_start_at_date",
-                      value: @event.start_at&.to_date,
+                      value: @event.start_at_date.presence || @event.start_at&.to_date,
                       class: "form-control shadow-sm" %>
                 </div>
                 <div class="col col-2">
                   <%= form.time_field :start_at,
                       name: "event[start_at_time]",
                       id: "event_start_at_time",
-                      value: @event.start_at&.strftime("%H:%M"),
+                      value: @event.start_at_time.presence || @event.start_at&.strftime("%H:%M"),
                       class: "form-control shadow-sm" %>
                 </div>
               </div>
@@ -33,14 +33,14 @@
                   <%= form.date_field :end_at,
                       name: "event[end_at_date]",
                       id: "event_end_at_date",
-                      value: @event.end_at&.to_date,
+                      value: @event.end_at_date.presence || @event.end_at&.to_date,
                       class: "form-control shadow-sm" %>
                 </div>
                 <div class="col col-2">
                   <%= form.time_field :end_at,
                       name: "event[end_at_time]",
                       id: "event_end_at_time",
-                      value: @event.end_at&.strftime("%H:%M"),
+                      value: @event.end_at_time.presence || @event.end_at&.strftime("%H:%M"),
                       class: "form-control shadow-sm" %>
                 </div>
               </div>

--- a/spec/requests/events_request_spec.rb
+++ b/spec/requests/events_request_spec.rb
@@ -26,6 +26,24 @@ RSpec.describe "Events", type: :request do
       expect(event.end_at).to eq(Time.zone.local(2026, 3, 14, 21, 0))
       expect(response).to redirect_to(event_path(event))
     end
+
+    it 'イベント名が未入力のときはエラー内容を表示する' do
+      post events_path, params: {
+        event: {
+          start_at_date: '2026-03-14',
+          start_at_time: '18:30',
+          end_at_date: '2026-03-14',
+          end_at_time: '21:00',
+          name: ''
+        }
+      }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to include('イベント名')
+      expect(response.body).to include('value="2026-03-14"')
+      expect(response.body).to include('value="18:30"')
+      expect(response.body).to include('value="21:00"')
+    end
   end
 
   describe 'PATCH /events/:id' do


### PR DESCRIPTION
- 🎫: https://github.com/mitakarb/beerkeeper/issues/1153
- Why? わかりにくいと不便なので
- What?
