### PR TITLE
Eventに開始日時 < 終了日時のバリデーションを追加

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -5,6 +5,7 @@ class Event < ApplicationRecord
   validates :start_at, presence: true
   validates :end_at, presence: true
   validates :name, presence: true
+  validate :end_at_after_start_at
 
   def organizer?(user)
     organizer_id == user&.id
@@ -30,5 +31,13 @@ class Event < ApplicationRecord
 
   def overbook?
     max_size && participations.count > max_size
+  end
+
+  def end_at_after_start_at
+    return if start_at.blank? || end_at.blank?
+
+    if end_at <= start_at
+      errors.add(:end_at, 'は開始日時より後にしてください')
+    end
   end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -17,6 +17,27 @@ RSpec.describe Event, type: :model do
         it { expect(event).to be_invalid }
       end
     end
+
+    describe 'start_at and end_at' do
+      context 'start_atがend_atより前の場合' do
+        let(:event) { FactoryBot.build(:event, start_at: Time.current, end_at: Time.current + 1.hour) }
+
+        it { expect(event).to be_valid }
+      end
+
+      context 'start_atがend_atと同じ場合' do
+        let(:now) { Time.current }
+        let(:event) { FactoryBot.build(:event, start_at: now, end_at: now) }
+
+        it { expect(event).to be_invalid }
+      end
+
+      context 'start_atがend_atより後の場合' do
+        let(:event) { FactoryBot.build(:event, start_at: Time.current + 1.hour, end_at: Time.current) }
+
+        it { expect(event).to be_invalid }
+      end
+    end
   end
 
   describe '#organizer?' do


### PR DESCRIPTION
## Summary
- Eventモデルに`end_at`が`start_at`より後であることを検証するカスタムバリデーションを追加
- `end_at <= start_at`の場合、バリデーションエラーになる
- 対応するモデルスペックを追加（正常系1件、異常系2件）

## Test plan
- [x] `start_at < end_at` → valid
- [x] `start_at == end_at` → invalid
- [x] `start_at > end_at` → invalid
- [x] 既存テスト全件パス（13 examples, 0 failures）