### PR TITLE
本番でマイグレーションが適用されない問題を修正

### DIFF
--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -7,7 +7,7 @@ if [ -z "${LD_PRELOAD+x}" ]; then
 fi
 
 # If running the rails server then create or migrate existing database
-if [ "${@: -2:1}" == "./bin/rails" ] && [ "${@: -1}" == "server" ]; then
+if [ "${1}" == "./bin/rails" ] && [ "${2}" == "server" ]; then
     ./bin/rails db:prepare
 fi
 

--- a/fly.toml
+++ b/fly.toml
@@ -9,8 +9,8 @@ console_command = '/rails/bin/rails console'
 
 [build]
 
-[deploy]
-  release_command = './bin/rails db:prepare'
+# release_command は専用の一時マシンで実行され data ボリュームがマウントされないため、
+# SQLite にマイグレーションを適用できない。マイグレーションは bin/docker-entrypoint が起動時に行う。
 
 [env]
   RAILS_LOG_TO_STDOUT = 'true'

--- a/spec/scripts/docker_entrypoint_spec.rb
+++ b/spec/scripts/docker_entrypoint_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+require 'fileutils'
+require 'open3'
+require 'tmpdir'
+
+RSpec.describe 'bin/docker-entrypoint' do
+  # rails を記録用スタブに差し替えて実行し、渡されたサブコマンドの一覧を返す
+  def rails_invocations(*args)
+    Dir.mktmpdir do |dir|
+      log = File.join(dir, 'rails-calls.log')
+
+      FileUtils.mkdir_p(File.join(dir, 'bin'))
+      FileUtils.cp(File.expand_path('../../bin/docker-entrypoint', __dir__), File.join(dir, 'bin/docker-entrypoint'))
+      FileUtils.chmod(0o755, File.join(dir, 'bin/docker-entrypoint'))
+      File.write(File.join(dir, 'bin/rails'), <<~STUB)
+        #!/bin/bash
+        echo "$@" >> "#{log}"
+      STUB
+      FileUtils.chmod(0o755, File.join(dir, 'bin/rails'))
+
+      Open3.capture2e('./bin/docker-entrypoint', *args, chdir: dir)
+
+      File.exist?(log) ? File.readlines(log).map(&:strip) : []
+    end
+  end
+
+  context 'Dockerfile の CMD どおりに rails server を起動したとき' do
+    it 'db:prepare でマイグレーションを適用する' do
+      expect(rails_invocations('./bin/rails', 'server', '-b', '0.0.0.0')).to include('db:prepare')
+    end
+
+    it 'server を起動する' do
+      expect(rails_invocations('./bin/rails', 'server', '-b', '0.0.0.0')).to include('server -b 0.0.0.0')
+    end
+  end
+
+  context 'server 以外のコマンドを実行したとき' do
+    it 'db:prepare を実行しない' do
+      expect(rails_invocations('./bin/rails', 'console')).not_to include('db:prepare')
+    end
+  end
+end


### PR DESCRIPTION
本番の `/events` などが `Could not find table 'event_cancellations'` で 500 になっていた。6/11 のイベント中止機能のデプロイ以降、Event を参照する全ページが落ちていた。

マイグレーションが本番に適用される経路が2つとも機能していなかった。

- `bin/docker-entrypoint` の db:prepare は最後の2引数が `./bin/rails server` かを見ていたが、Dockerfile の CMD は `["./bin/rails", "server", "-b", "0.0.0.0"]` で末尾が `-b` `0.0.0.0` になるため成立しない。Fly 導入時から一度も実行されていなかった。上流の Rails と同じ先頭2引数の判定に直した。
- `fly.toml` の `release_command` は data ボリュームがマウントされない一時マシンで動くため、ボリューム上の SQLite には反映されない。成功したように見えるだけなので削除した。

回帰防止に、Dockerfile の CMD と同じ引数で entrypoint を実行して db:prepare が呼ばれることを確認する spec を追加した。